### PR TITLE
GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on: [ push, pull_request ]
+
+jobs:
+
+  build:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        build_configuration: [ Release, Debug ]
+        build_platform: [ x64, Win32 ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow --tags
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.0
+
+      - name: Show MSBuild version
+        run: msbuild -version
+
+      - name: Run MSBuild
+        run: msbuild NppTags.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin_dll_(${{ matrix.build_platform }})_(${{ matrix.build_configuration }})
+          path: ${{ matrix.build_platform }}/${{ matrix.build_configuration }}/NppTags.dll

--- a/version_git.sh
+++ b/version_git.sh
@@ -36,7 +36,7 @@ function create_version_git_h()
 
 	# Get additional version info from git
 	echo "Retrieving additional version information from git..."
-	VERSION=$(git describe --tags --abbrev=0 | grep -oP '\d+\.\d+\.\d+')
+	VERSION=$(git describe --tags --abbrev=0 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 	VERSION_NUMBERS=$(echo $VERSION | tr "." ","),0
 	YEAR=$(date +%Y)
 


### PR DESCRIPTION
- added github actions, adapted version_git.sh therefore
see https://github.com/chcg/npptags/actions/runs/108187403

Win32 dlls are currently build without the change from other of your projects: 

    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>

So either the vcxproj file need to be adapted or the CI build for Win32