### PR TITLE
Added support for widechar filenames

### DIFF
--- a/DlgSelectTag.cpp
+++ b/DlgSelectTag.cpp
@@ -68,11 +68,8 @@ static void CreateColumns(HWND hList)
 static void FillList(HWND hList)
 {
 	// Get the filename of the current document
-	WCHAR tmp[MAX_PATH];
-	SendMessage(g_nppData._nppHandle, NPPM_GETFULLCURRENTPATH, MAX_PATH, (LPARAM) &tmp);
-
-	char curPath[MAX_PATH];
-	Unicode2Ansi(curPath, tmp, MAX_PATH);
+	WCHAR curPath[MAX_PATH];
+	SendMessage(g_nppData._nppHandle, NPPM_GETFULLCURRENTPATH, MAX_PATH, (LPARAM) &curPath);
 
 	// To through the found items
 	LV_ITEM item;
@@ -98,15 +95,16 @@ static void FillList(HWND hList)
 		{
 			item.iItem = insertedItem;
 			item.iSubItem = col;
+			wstr.clear();
 
 			// Add the subitems in the proper column
 			switch (col)
 			{
 				case COL_FILE:      // Filename
-					str = s_foundTags.at(i).getFile();
+					wstr = s_foundTags.at(i).getFile();
 
 					// Is it the current file, preselect the tag
-					if (_stricmp(curPath, str.c_str()) == 0 && selItem < 0)
+					if (_wcsicmp(curPath, wstr.c_str()) == 0 && selItem < 0)
 						selItem = i;
 					break;
 
@@ -128,8 +126,9 @@ static void FillList(HWND hList)
 					return;
 			}
 
-			wstring wstr2(str.begin(), str.end());
-			item.pszText = (LPWSTR) wstr2.c_str();
+			if (wstr.empty())
+				wstr.assign(str.begin(), str.end());
+			item.pszText = const_cast<LPWSTR>(wstr.c_str());
 			ListView_SetItem(hList, &item);
 		}
 	}

--- a/DlgTree.cpp
+++ b/DlgTree.cpp
@@ -319,7 +319,7 @@ static void ShowTagsProperties()
 			std::string str = "Tag Name: " + tag->getFullTag();
 			str += "\r\nLanguage: " + tag->getLanguage();
 			str += "\r\nType: " + tag->getType();
-			str += "\r\nFile: " + tag->getFile();
+			str += "\r\nFile: " + tag->getFileUTF8();
 			if (tag->getMemberOf().length() != 0)
 				str += "\r\nMember of: " + tag->getMemberOf();
 			if (tag->getDetails().length() != 0)

--- a/NppTags.cpp
+++ b/NppTags.cpp
@@ -302,13 +302,11 @@ static void StoreCurrentPosition()
 	SendMessage(g_nppData._nppHandle, NPPM_GETFULLCURRENTPATH, MAX_PATH, (LPARAM) &wcurFile);
 	if (wcslen(wcurFile) == 0)
 		return;
-	CHAR curFile[MAX_PATH];
-	Unicode2Ansi(curFile, wcurFile, MAX_PATH);
 
 	// Store the information
 	Tag tag;
 	tag.setLine(line + 1);		// Line number from Scintilla is 0-based
-	tag.setFile(curFile);
+	tag.setFile(wcurFile);
 	s_JumpBackStack.push_back(tag);
 
 	// Don't let the stack get too big
@@ -326,8 +324,7 @@ void JumpToTag(Tag* pTag, bool storeCurPos)
 		StoreCurrentPosition();
 
 	// Open the file
-	string str = pTag->getFile();
-	wstring wstr(str.begin(), str.end());
+	wstring wstr = pTag->getFile();
 	SendMessage(g_nppData._nppHandle, NPPM_DOOPEN, 0, (LPARAM) wstr.c_str());
 
 	// Go to the right location

--- a/NppTags.vcxproj
+++ b/NppTags.vcxproj
@@ -34,17 +34,17 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -92,9 +92,33 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <CustomBuildBeforeTargets>
     </CustomBuildBeforeTargets>
+    <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <CustomBuildBeforeTargets />
+    <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <VcpkgInstalledDir>
+    </VcpkgInstalledDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <VcpkgInstalledDir>
+    </VcpkgInstalledDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <VcpkgInstalledDir>
+    </VcpkgInstalledDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <VcpkgInstalledDir>
+    </VcpkgInstalledDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -119,6 +143,7 @@
     </Link>
     <PreBuildEvent>
       <Command>call $(SolutionDir)version_git.bat</Command>
+      <Message>Make version_git.h</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -143,6 +168,7 @@
     </Link>
     <PreBuildEvent>
       <Command>call $(SolutionDir)version_git.bat</Command>
+      <Message>Make version_git.h</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -166,6 +192,7 @@
     </Link>
     <PreBuildEvent>
       <Command>call $(SolutionDir)version_git.bat</Command>
+      <Message>Make version_git.h</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -188,6 +215,7 @@
     </Link>
     <PreBuildEvent>
       <Command>call $(SolutionDir)version_git.bat</Command>
+      <Message>Make version_git.h</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/NppTags.vcxproj
+++ b/NppTags.vcxproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/Tag.cpp
+++ b/Tag.cpp
@@ -123,7 +123,10 @@ Tag& Tag::operator=(const tagEntry tag)
 
 	// Fill the straight forward fields
 	_tag = tag.name;
-	_file = tag.file;
+	// Conversion from UTF8 to wstring
+	const int size_needed = MultiByteToWideChar(CP_UTF8, 0, tag.file, strlen(tag.file), NULL, 0);
+	_file.assign(size_needed, L'\0');
+	MultiByteToWideChar(CP_UTF8, 0, tag.file, strlen(tag.file), &_file[0], _file.size());
 	_line = tag.address.lineNumber;
 	if (_line == 0)
 	{
@@ -214,14 +217,14 @@ bool Tag::isType(LPCSTR szType)
 /////////////////////////////////////////////////////////////////////////////
 // Returns the filename without the extension
 
-std::string Tag::getBaseFile()
+std::wstring Tag::getBaseFile()
 {
 	// Split the filename
-	char szSpoolDrive[_MAX_DRIVE];
-	char szSpoolDir[_MAX_DIR];
-	char szSpoolFile[_MAX_FNAME];
-	char szSpoolExt[_MAX_EXT];
-	_splitpath_s(_file.c_str(), szSpoolDrive, szSpoolDir, szSpoolFile, szSpoolExt);
+	wchar_t szSpoolDrive[_MAX_DRIVE];
+	wchar_t szSpoolDir[_MAX_DIR];
+	wchar_t szSpoolFile[_MAX_FNAME];
+	wchar_t szSpoolExt[_MAX_EXT];
+	_wsplitpath_s(_file.c_str(), szSpoolDrive, szSpoolDir, szSpoolFile, szSpoolExt);
 
 	return szSpoolFile;
 }
@@ -229,17 +232,17 @@ std::string Tag::getBaseFile()
 /////////////////////////////////////////////////////////////////////////////
 // Returns the full filename without the extension
 
-std::string Tag::getFullBaseFile()
+std::wstring Tag::getFullBaseFile()
 {
 	// Split the filename
-	char szDrive[_MAX_DRIVE];
-	char szDir[_MAX_DIR];
-	char szFile[_MAX_FNAME];
-	char szExt[_MAX_EXT];
-	_splitpath_s(_file.c_str(), szDrive, szDir, szFile, szExt);
+	wchar_t szDrive[_MAX_DRIVE];
+	wchar_t szDir[_MAX_DIR];
+	wchar_t szFile[_MAX_FNAME];
+	wchar_t szExt[_MAX_EXT];
+	_wsplitpath_s(_file.c_str(), szDrive, szDir, szFile, szExt);
 
 	// Reconstruct the base filename
-	std::string ret = szDrive;
+	std::wstring ret = szDrive;
 	ret += szDir;
 	ret += szFile;
 	return ret;
@@ -340,7 +343,7 @@ void Tag::SetFromDB(SqliteStatement* stmt)
 	// Fill the members from the active Sqlite statement
 	_idx = stmt->GetIntColumn("Idx");
 	_tag = stmt->GetTextColumn("Tag");
-	_file = stmt->GetTextColumn("File");
+	_file = stmt->GetWTextColumn("File");
 	_line = stmt->GetIntColumn("Line");
 	_pattern = stmt->GetTextColumn("Pattern");
 	_type = stmt->GetTextColumn("Type");

--- a/Tag.cpp
+++ b/Tag.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 //                                                                         //
 //  NppTags - CTags plugin for Notepad++                                   //
-//  Copyright (C) 2013 Frank Fesevur                                       //
+//  Copyright (C) 2013 Frank Fesevur and Mark_Pr                           //
 //                                                                         //
 //  This program is free software; you can redistribute it and/or modify   //
 //  it under the terms of the GNU General Public License as published by   //
@@ -302,6 +302,13 @@ std::string Tag::getDetails()
 	}
 
 	return ret;
+}
+
+std::string Tag::getFileUTF8()
+{
+	CHAR buf[MAX_PATH];
+	WideCharToMultiByte(CP_UTF8, 0, _file.c_str(), -1, buf, MAX_PATH, NULL, NULL);
+	return buf;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Tag.h
+++ b/Tag.h
@@ -44,6 +44,7 @@ public:
 	std::string getTag()			{ return _tag; };
 	std::string getFullTag()		{ return _tag + _signature; };
 	std::wstring getFile()			{ return _file; };
+	std::string getFileUTF8();
 	int getLine()					{ return _line; };
 	std::string getPattern()		{ return _pattern; }
 	std::string getType()			{ return _type; };

--- a/Tag.h
+++ b/Tag.h
@@ -43,27 +43,27 @@ public:
 	int getIdx()					{ return _idx; };
 	std::string getTag()			{ return _tag; };
 	std::string getFullTag()		{ return _tag + _signature; };
-	std::string getFile()			{ return _file; };
+	std::wstring getFile()			{ return _file; };
 	int getLine()					{ return _line; };
 	std::string getPattern()		{ return _pattern; }
 	std::string getType()			{ return _type; };
 	std::string getLanguage()		{ return _language; };
 	std::string getMemberOf()		{ return _memberOf; };
-	std::string getBaseFile();
-	std::string getFullBaseFile();
+	std::wstring getBaseFile();
+	std::wstring getFullBaseFile();
 	std::string getDetails();
 	bool isMemberOf(LPCSTR);
 	bool isType(LPCSTR);
 	bool thisFileOnly()				{ return _thisFileOnly; };
 
 	void setTag(std::string t)		{ _tag = t; };
-	void setFile(std::string f)		{ _file = f; };
+	void setFile(std::wstring f)		{ _file = f; };
 	void setLine(int i)				{ _line = i; };
 
 protected:
 	int _idx;							// Index field in database
 	std::string _tag;					// Name of the tag
-	std::string _file;					// What file is the tag in?
+	std::wstring _file;					// What file is the tag in?
 	int _line;							// On which line it is?
 	std::string _pattern;				// Search pattern to find the tag with
 	std::string _type;					// What is its type?

--- a/TagsDatabase.cpp
+++ b/TagsDatabase.cpp
@@ -384,6 +384,8 @@ bool TagsDatabase::ImportTags()
 		BeginTransaction();
 		while (tagsNext(file, &entry) == TagSuccess)
 		{
+			if (entry.name[0] == '!' || entry.kind == 0)
+				continue;
 			// Put it in the array
 			tag = entry;
 

--- a/version_git.bat
+++ b/version_git.bat
@@ -19,6 +19,14 @@ if exist C:\Cygwin\bin\bash.exe (
 	bash version_git.sh
 	exit /b 0
 )
+if exist C:\Cygwin64\bin\bash.exe (
+
+	echo Using bash from Cygwin
+	setlocal
+	PATH=C:\Cygwin64\bin
+	bash version_git.sh
+	exit /b 0
+)
 
 REM No Cygwin or Git for Windows installed
 REM If there is a file assume if is properly generated


### PR DESCRIPTION
Added support for projects, contains not-ascii characters in path.

Old:

Attempting to jump to tag, filename for which contains non-ascii character fails with this message:
<img width="1440" height="857" alt="image" src="https://github.com/user-attachments/assets/6e7d5a4e-d6ca-4b33-9fb3-61544f16f698" />

New:
Jumping works fine
<img width="1080" height="688" alt="image" src="https://github.com/user-attachments/assets/f9e7d88d-1a8b-4b86-98a7-9e70e9750ee8" />

Tag filename storage changed to std::wstring, usage in all places except "Tag properties" dialog changed to wide chars. In tag properties dialog it stills shows invalid filepath.
